### PR TITLE
Fix `SyntaxWarning: invalid escape sequence`

### DIFF
--- a/cp2kdata/block_parser/dft_plus_u.py
+++ b/cp2kdata/block_parser/dft_plus_u.py
@@ -2,7 +2,7 @@ import regex as re
 import numpy as np
 
 PLUS_U_RE = re.compile(
-    """
+    r"""
     \sDFT\+U\soccupations\sof\sspin\s(?P<spin>\d)
     \sfor\sthe\satoms\sof\satomic\skind\s(?P<kind>\d+):\s\w+\s*\n
     \n

--- a/cp2kdata/block_parser/hirshfeld.py
+++ b/cp2kdata/block_parser/hirshfeld.py
@@ -2,7 +2,7 @@ import regex as re
 import numpy as np
 
 HIRSHFELD_RE = re.compile(
-    """
+    r"""
     \s+Hirshfeld\sCharges\s*\n
     \n
     \s\#.+\n


### PR DESCRIPTION
```
/opt/hostedtoolcache/Python/3.12.3/x64/lib/python3.12/site-packages/cp2kdata/block_parser/dft_plus_u.py:5: SyntaxWarning: invalid escape sequence '\s'
  """
/opt/hostedtoolcache/Python/3.12.3/x64/lib/python3.12/site-packages/cp2kdata/block_parser/hirshfeld.py:5: SyntaxWarning: invalid escape sequence '\s'
  """
```