### PR TITLE
remove the dependency of property num_atoms on the cube file content

### DIFF
--- a/tests/test_cube/test_cube.py
+++ b/tests/test_cube/test_cube.py
@@ -1,7 +1,9 @@
-from cp2kdata import Cp2kCube
 import os
+
 import pytest
 import numpy as np
+
+from cp2kdata import Cp2kCube
 
 
 path_prefix = "tests/test_cube/"


### PR DESCRIPTION
remove the dependency of property num_atoms on the cube file content. When writing a new cube file, the num_atoms property is obtained from self.stc which is ase Atoms object.